### PR TITLE
Update to firmware 1.64

### DIFF
--- a/config.h
+++ b/config.h
@@ -5,7 +5,7 @@
 #define MPPT_100_30    // Define used Victron Device
 
 // Supported:
-// "MPPT 75 | 10"
+// "MPPT 75 | 10" tested with FW 1.64
 // "MPPT 75 | 15" tested with FW 1.56
 // "MPPT 100 | 20" tested with FW 1.5 / 1.56
 // "MPPT 100 | 30" tested with FW 1.59
@@ -20,7 +20,7 @@
 	const byte buffsize = 32;
 	const byte value_bytes = 33;
 	const byte label_bytes = 9;
-	const byte num_keywords = 18;
+	const byte num_keywords = 20;
 
 	char keywords[num_keywords][label_bytes] = {
 	"PID",
@@ -31,6 +31,8 @@
 	"VPV",
 	"PPV",
 	"CS",
+	"MPPT",
+	"OR",
 	"ERR",
 	"LOAD",
 	"IL",


### PR DESCRIPTION
Update to support SmartSolar 75/10 with firmware 1.64
Tested and running

```
01:23:46.827 -> PID,0xA074
01:23:46.827 -> FW,164
01:23:46.827 -> SER#,MISERIAL
01:23:46.827 -> V,13190
01:23:46.827 -> I,0
01:23:46.827 -> VPV,10
01:23:46.827 -> PPV,0
01:23:46.827 -> CS,0
01:23:46.827 -> MPPT,0
01:23:46.827 -> OR,0x00000001
01:23:46.827 -> ERR,0
01:23:46.827 -> LOAD,ON
01:23:46.827 -> IL,0
01:23:46.827 -> H19,0
01:23:46.827 -> H20,0
01:23:46.827 -> H21,0
01:23:46.827 -> H22,0
01:23:46.827 -> H23,0
01:23:46.827 -> HSDS,0
01:23:46.827 -> Checksum,�
```